### PR TITLE
add ubuntu job even if fail

### DIFF
--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -29,7 +29,12 @@ jobs:
       - run: flutter analyze --fatal-infos --fatal-warnings .
 
   widget_test:
-    runs-on: macos-latest # TODO: change to ubuntu.
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false # I want results from all OSes even if one fails.
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest] # TODO: https://github.com/sensuikan1973/pedax/issues/12
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1

--- a/.github/workflows/flutter_integration_test.yaml
+++ b/.github/workflows/flutter_integration_test.yaml
@@ -14,14 +14,14 @@ jobs:
     strategy:
       fail-fast: false # I want results from all OSes even if one fails.
       matrix:
-        os: [windows-latest, macos-latest] # TODO: add ubuntsu-latest. See: https://github.com/sensuikan1973/pedax/issues/7
+        os: [windows-latest, macos-latest, ubuntu-latest] # TODO: https://github.com/sensuikan1973/pedax/issues/7
         include:
-          # - os: ubuntu-latest
-          #   device: linux
-          #   setup-script: |-
-          #     flutter config --enable-linux-desktop
-          #     sudo apt-get update
-          #     sudo apt-get install -y libgtk-3-dev libx11-dev pkg-config cmake ninja-build libblkid-dev liblzma-dev
+          - os: ubuntu-latest
+            device: linux
+            setup-script: |-
+              flutter config --enable-linux-desktop
+              sudo apt-get update
+              sudo apt-get install -y libgtk-3-dev libx11-dev pkg-config cmake ninja-build libblkid-dev liblzma-dev
           - os: windows-latest
             device: windows
             setup-script: flutter config --enable-windows-desktop


### PR DESCRIPTION
ubuntu だとなんか失敗するものがちょくちょくあるが、失敗しようが常に走らせておく。

いつどの flutter version や差分で通ったかを気づきやすくしておくことの方が重要。
赤くしておくことで健全さを保っていきましょい。