### PR TITLE
fix packing target dll on windows 

### DIFF
--- a/.github/scripts/prepare_to_pack_for_windows.sh
+++ b/.github/scripts/prepare_to_pack_for_windows.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
-# See: https://flutter.dev/desktop#windows
-# See: https://github.com/sensuikan1973/pedax/pull/71#issuecomment-798849250
-# See: https://github.com/sensuikan1973/pedax/pull/83#issuecomment-803240876
-msvc_path="/c/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Redist/MSVC"
-ls "$msvc_path"
+# See: https://flutter.dev/desktop#building-your-own-zip-file-for-windows
+# REF: https://github.com/sensuikan1973/pedax/pull/71#issuecomment-798849250
+# REF: https://github.com/sensuikan1973/pedax/pull/83#issuecomment-803240876
+system32_path="/c/Windows/System32"
+ls "$system32_path"
 
-target_vc_path="$msvc_path/14.28.29910/x64/Microsoft.VC142.CRT"
 dest_path="build/windows/runner/Release/"
-cp "$target_vc_path/vcruntime140.dll" $dest_path
-cp "$target_vc_path/vcruntime140_1.dll" $dest_path
-cp "$target_vc_path/msvcp140.dll" $dest_path
+cp "$system32_path/vcruntime140.dll" $dest_path
+cp "$system32_path/vcruntime140_1.dll" $dest_path
+cp "$system32_path/msvcp140.dll" $dest_path

--- a/.github/workflows/flutter_build.yaml
+++ b/.github/workflows/flutter_build.yaml
@@ -5,10 +5,10 @@ name: Flutter Build
 
 on:
   pull_request:
-    paths: ['**.dart','pubspec.*', '.github/workflows/flutter_build.yaml', 'macos/**', 'linux/**', 'windows/**', 'assets/**']
+    paths: ['**.dart','pubspec.*', '.github/workflows/flutter_build.yaml', '.github/scripts/**', 'macos/**', 'linux/**', 'windows/**', 'assets/**']
   push:
     branches: [main]
-    paths: ['**.dart','pubspec.*', '.github/workflows/flutter_build.yaml', 'macos/**', 'linux/**', 'windows/**', 'assets/**']
+    paths: ['**.dart','pubspec.*', '.github/workflows/flutter_build.yaml', '.github/scripts/**', 'macos/**', 'linux/**', 'windows/**', 'assets/**']
 
 jobs:
   build:

--- a/.github/workflows/flutter_build.yaml
+++ b/.github/workflows/flutter_build.yaml
@@ -52,8 +52,8 @@ jobs:
       - name: build
         run: flutter build ${{ matrix.subcommand }} --${{ matrix.mode }}
 
-      # - name: debug
-      #   uses: mxschmitt/action-tmate@v3
+      - name: debug
+        uses: mxschmitt/action-tmate@v3
 
       - name: prepare to pack
         shell: bash

--- a/.github/workflows/flutter_build.yaml
+++ b/.github/workflows/flutter_build.yaml
@@ -52,8 +52,8 @@ jobs:
       - name: build
         run: flutter build ${{ matrix.subcommand }} --${{ matrix.mode }}
 
-      - name: debug
-        uses: mxschmitt/action-tmate@v3
+      # - name: debug
+      #   uses: mxschmitt/action-tmate@v3
 
       - name: prepare to pack
         shell: bash

--- a/.github/workflows/flutter_integration_test.yaml
+++ b/.github/workflows/flutter_integration_test.yaml
@@ -2,10 +2,10 @@ name: Flutter Integration Test
 
 on:
   pull_request:
-    paths: ['**.dart', 'pubspec.*', '.github/workflows/flutter_integration_test.yaml', 'macos/**', 'linux/**', 'windows/**', 'assets/**']
+    paths: ['**.dart', 'pubspec.*', '.github/workflows/flutter_integration_test.yaml', '.github/scripts/**', 'macos/**', 'linux/**', 'windows/**', 'assets/**']
   push:
     branches: [main]
-    paths: ['**.dart', 'pubspec.*', '.github/workflows/flutter_integration_test.yaml', 'macos/**', 'linux/**', 'windows/**', 'assets/**']
+    paths: ['**.dart', 'pubspec.*', '.github/workflows/flutter_integration_test.yaml', '.github/scripts/**', 'macos/**', 'linux/**', 'windows/**', 'assets/**']
 
 jobs:
   integration_test:


### PR DESCRIPTION
See: https://flutter.dev/desktop#building-your-own-zip-file-for-windows

> The Visual C++ redistributables. You can use any of the methods shown in the deployment example walkthroughs on the Microsoft site to ensure that end users have the C++ redistributables. If you use the application-local option, you need to copy:
msvcp140.dll
vcruntime140.dll
vcruntime140_1.dll
These 3 files can be found in C:\Windows\System32 if installed on your PC. Place the DLL files in the directory next to the executable and the other DLLs, and bundle them together in a zip file. 