### PR TITLE
specify windows icon property

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,4 +84,4 @@ msix_config:
   # vs_generated_images_folder_path: C:\<PathToFolder>\Images
   # icons_background_color: transparent (or some color like: '#ffffff')
   architecture: x64
-  # capabilities: 'internetClient,location,microphone,webcam'
+  capabilities: ''

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,9 +78,9 @@ msix_config:
   msix_version: 0.4.4.0
   publisher: CN=4CCE9711-39B6-4ECC-AA74-A350014A69B0
   languages: en, ja
-  # logo_path: C:\<PathToIcon>\<Logo.png>
-  # start_menu_icon_path: C:\<PathToIcon>\<Icon.png>
-  # tile_icon_path: C:\<PathToIcon>\<Icon.png>
+  logo_path: assets/images/pedax_logo.png
+  start_menu_icon_path: assets/images/pedax_logo.png
+  tile_icon_path: assets/images/pedax_logo.png
   # vs_generated_images_folder_path: C:\<PathToFolder>\Images
   # icons_background_color: transparent (or some color like: '#ffffff')
   architecture: x64


### PR DESCRIPTION
https://partner.microsoft.com/ja-jp/dashboard/submissions/api/products/9NLNZCKH0L9H/certreport/2000000000090029185

> App Policies: 10.1.1 Inaccurate Representation - Icon
>
> Notes To Developer
> 
> The available product tile icons include an icon that does not relate to the product. Icons must uniquely represent product so users associate icons with the appropriate product and do not confuse one product for another. For information about tiles see https://docs.microsoft.com/en-us/windows/uwp/controls-and-patterns/tiles-and-notifications-app-assets.
>
> Please Note
> Your current certification results might differ from earlier submissions because Microsoft Store policy requirements can change over time. When policies change, we might re-test according to the new requirements regardless of the submission type. Please always rely on your most recent certification results.