### PR TITLE
fix confusing shortcut key

### DIFF
--- a/lib/board/pedax_shortcuts/copy_moves_shortcut.dart
+++ b/lib/board/pedax_shortcuts/copy_moves_shortcut.dart
@@ -18,7 +18,7 @@ class CopyMovesShorcut implements PedaxShorcut {
   String label(final AppLocalizations localizations) => localizations.shortcutLabelCopyMoves;
 
   @override
-  String get keys => Platform.isMacOS ? '^C or ⌘C' : 'Ctrl + C';
+  String get keys => Platform.isMacOS ? '^$_keyLabel or ⌘$_keyLabel' : 'Ctrl + $_keyLabel';
 
   @override
   bool fired(final RawKeyEvent keyEvent) =>
@@ -29,4 +29,9 @@ class CopyMovesShorcut implements PedaxShorcut {
   Future<void> runEvent() async => Clipboard.setData(
         ClipboardData(text: boardNotifier.value.currentMovesWithoutPassString),
       );
+
+  @visibleForTesting
+  static LogicalKeyboardKey get logicalKey => LogicalKeyboardKey.keyC;
+
+  String get _keyLabel => logicalKey.keyLabel.toUpperCase();
 }

--- a/lib/board/pedax_shortcuts/init_shortcut.dart
+++ b/lib/board/pedax_shortcuts/init_shortcut.dart
@@ -18,7 +18,7 @@ class InitShorcut implements PedaxShorcut {
   String label(final AppLocalizations localizations) => localizations.shortcutLabelInit;
 
   @override
-  String get keys => Platform.isMacOS ? '⌃I or ⌘I' : 'Ctrl + I';
+  String get keys => Platform.isMacOS ? '⌃$_keyLabel or ⌘$_keyLabel' : 'Ctrl + $_keyLabel';
 
   @override
   bool fired(final RawKeyEvent keyEvent) =>
@@ -30,4 +30,6 @@ class InitShorcut implements PedaxShorcut {
 
   @visibleForTesting
   static LogicalKeyboardKey get logicalKey => LogicalKeyboardKey.keyI;
+
+  String get _keyLabel => logicalKey.keyLabel.toUpperCase();
 }

--- a/lib/board/pedax_shortcuts/init_shortcut.dart
+++ b/lib/board/pedax_shortcuts/init_shortcut.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart'; // ignore: depend_on_referenced_packages
@@ -16,10 +18,12 @@ class InitShorcut implements PedaxShorcut {
   String label(final AppLocalizations localizations) => localizations.shortcutLabelInit;
 
   @override
-  String get keys => logicalKey.keyLabel.toUpperCase();
+  String get keys => Platform.isMacOS ? '⌃I or ⌘I' : 'Ctrl + I';
 
   @override
-  bool fired(final RawKeyEvent keyEvent) => keyEvent.isKeyPressed(logicalKey);
+  bool fired(final RawKeyEvent keyEvent) =>
+      (keyEvent.isControlPressed && keyEvent.isKeyPressed(logicalKey)) ||
+      (keyEvent.data.isModifierPressed(ModifierKey.metaModifier) && keyEvent.isKeyPressed(logicalKey));
 
   @override
   Future<void> runEvent() async => boardNotifier.requestInit();

--- a/lib/board/pedax_shortcuts/new_shortcut.dart
+++ b/lib/board/pedax_shortcuts/new_shortcut.dart
@@ -18,7 +18,7 @@ class NewShorcut implements PedaxShorcut {
   String label(final AppLocalizations localizations) => localizations.shortcutLabelNew;
 
   @override
-  String get keys => Platform.isMacOS ? '⌃N or ⌘N' : 'Ctrl + N';
+  String get keys => Platform.isMacOS ? '⌃$_keyLabel or ⌘$_keyLabel' : 'Ctrl + $_keyLabel';
 
   @override
   bool fired(final RawKeyEvent keyEvent) =>

--- a/lib/board/pedax_shortcuts/new_shortcut.dart
+++ b/lib/board/pedax_shortcuts/new_shortcut.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart'; // ignore: depend_on_referenced_packages
@@ -16,14 +18,18 @@ class NewShorcut implements PedaxShorcut {
   String label(final AppLocalizations localizations) => localizations.shortcutLabelNew;
 
   @override
-  String get keys => logicalKey.keyLabel.toUpperCase();
+  String get keys => Platform.isMacOS ? '⌃N or ⌘N' : 'Ctrl + N';
 
   @override
-  bool fired(final RawKeyEvent keyEvent) => keyEvent.isKeyPressed(logicalKey);
+  bool fired(final RawKeyEvent keyEvent) =>
+      (keyEvent.isControlPressed && keyEvent.isKeyPressed(logicalKey)) ||
+      (keyEvent.data.isModifierPressed(ModifierKey.metaModifier) && keyEvent.isKeyPressed(logicalKey));
 
   @override
   Future<void> runEvent() async => boardNotifier.requestNew();
 
   @visibleForTesting
   static LogicalKeyboardKey get logicalKey => LogicalKeyboardKey.keyN;
+
+  String get _keyLabel => logicalKey.keyLabel.toUpperCase();
 }

--- a/lib/board/pedax_shortcuts/paste_moves_shortcut.dart
+++ b/lib/board/pedax_shortcuts/paste_moves_shortcut.dart
@@ -18,7 +18,7 @@ class PasteMovesShorcut implements PedaxShorcut {
   String label(final AppLocalizations localizations) => localizations.shortcutLabelPasteMoves;
 
   @override
-  String get keys => Platform.isMacOS ? '⌃$_keyLabel or ⌘$_keyLabel' : 'Ctrl + $_keyLabel';
+  String get keys => Platform.isMacOS ? '^$_keyLabel or ⌘$_keyLabel' : 'Ctrl + $_keyLabel';
 
   @override
   bool fired(final RawKeyEvent keyEvent) =>

--- a/lib/board/pedax_shortcuts/paste_moves_shortcut.dart
+++ b/lib/board/pedax_shortcuts/paste_moves_shortcut.dart
@@ -18,12 +18,12 @@ class PasteMovesShorcut implements PedaxShorcut {
   String label(final AppLocalizations localizations) => localizations.shortcutLabelPasteMoves;
 
   @override
-  String get keys => Platform.isMacOS ? '⌃V or ⌘V' : 'Ctrl + V';
+  String get keys => Platform.isMacOS ? '⌃$_keyLabel or ⌘$_keyLabel' : 'Ctrl + $_keyLabel';
 
   @override
   bool fired(final RawKeyEvent keyEvent) =>
-      (keyEvent.isControlPressed && keyEvent.isKeyPressed(LogicalKeyboardKey.keyV)) ||
-      (keyEvent.data.isModifierPressed(ModifierKey.metaModifier) && keyEvent.isKeyPressed(LogicalKeyboardKey.keyV));
+      (keyEvent.isControlPressed && keyEvent.isKeyPressed(logicalKey)) ||
+      (keyEvent.data.isModifierPressed(ModifierKey.metaModifier) && keyEvent.isKeyPressed(logicalKey));
 
   @override
   Future<void> runEvent() async {
@@ -33,4 +33,9 @@ class PasteMovesShorcut implements PedaxShorcut {
       ..requestInit()
       ..requestPlay(clipboardData.text!);
   }
+
+  @visibleForTesting
+  static LogicalKeyboardKey get logicalKey => LogicalKeyboardKey.keyV;
+
+  String get _keyLabel => logicalKey.keyLabel.toUpperCase();
 }

--- a/lib/board/pedax_shortcuts/redo_shortcut.dart
+++ b/lib/board/pedax_shortcuts/redo_shortcut.dart
@@ -16,17 +16,17 @@ class RedoShorcut implements PedaxShorcut {
   String label(final AppLocalizations localizations) => localizations.shortcutLabelRedo;
 
   @override
-  String get keys => '${logicalKeyR.keyLabel.toUpperCase()} or →';
+  String get keys => '${logicalKey.keyLabel.toUpperCase()} or ${logicalKeyArrowRight.keyLabel.toUpperCase()}';
 
   @override
   bool fired(final RawKeyEvent keyEvent) =>
-      keyEvent.isKeyPressed(logicalKeyR) || keyEvent.isKeyPressed(logicalKeyArrowRight);
+      keyEvent.isKeyPressed(logicalKey) || keyEvent.isKeyPressed(logicalKeyArrowRight);
 
   @override
   Future<void> runEvent() async => boardNotifier.requestRedo();
 
   @visibleForTesting
-  static LogicalKeyboardKey get logicalKeyR => LogicalKeyboardKey.keyR;
+  static LogicalKeyboardKey get logicalKey => LogicalKeyboardKey.keyR;
 
   @visibleForTesting
   static LogicalKeyboardKey get logicalKeyArrowRight => LogicalKeyboardKey.arrowRight;

--- a/lib/board/pedax_shortcuts/redo_shortcut.dart
+++ b/lib/board/pedax_shortcuts/redo_shortcut.dart
@@ -16,7 +16,7 @@ class RedoShorcut implements PedaxShorcut {
   String label(final AppLocalizations localizations) => localizations.shortcutLabelRedo;
 
   @override
-  String get keys => '${logicalKey.keyLabel.toUpperCase()} or ${logicalKeyArrowRight.keyLabel.toUpperCase()}';
+  String get keys => '${logicalKey.keyLabel.toUpperCase()} or →';
 
   @override
   bool fired(final RawKeyEvent keyEvent) =>

--- a/lib/board/pedax_shortcuts/undo_shortcut.dart
+++ b/lib/board/pedax_shortcuts/undo_shortcut.dart
@@ -16,7 +16,7 @@ class UndoShorcut implements PedaxShorcut {
   String label(final AppLocalizations localizations) => localizations.shortcutLabelUndo;
 
   @override
-  String get keys => '${logicalKeyU.keyLabel.toUpperCase()} or ${logicalKeyArrowLeft.keyLabel.toUpperCase()}';
+  String get keys => '${logicalKeyU.keyLabel.toUpperCase()} or ←';
 
   @override
   bool fired(final RawKeyEvent keyEvent) =>

--- a/lib/board/pedax_shortcuts/undo_shortcut.dart
+++ b/lib/board/pedax_shortcuts/undo_shortcut.dart
@@ -16,7 +16,7 @@ class UndoShorcut implements PedaxShorcut {
   String label(final AppLocalizations localizations) => localizations.shortcutLabelUndo;
 
   @override
-  String get keys => '${logicalKeyU.keyLabel.toUpperCase()} or ←';
+  String get keys => '${logicalKeyU.keyLabel.toUpperCase()} or ${logicalKeyArrowLeft.keyLabel.toUpperCase()}';
 
   @override
   bool fired(final RawKeyEvent keyEvent) =>

--- a/test/arrange_discs_mode_test.dart
+++ b/test/arrange_discs_mode_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart'; // ignore: depend_on_referenced_packages
 import 'package:flutter_test/flutter_test.dart';
 import 'package:logger/logger.dart';
@@ -87,7 +88,9 @@ Future<void> main() async {
       expectStoneCoordinates(tester, ['a8'], SquareType.white);
 
       // edaxNew
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
       await tester.sendKeyEvent(NewShorcut.logicalKey);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
       await waitEdaxServerResponsed(tester);
       await tester.pump();
       expectStoneNum(tester, SquareType.black, 3);
@@ -95,8 +98,9 @@ Future<void> main() async {
       expectStoneNum(tester, SquareType.white, 2);
       expectStoneCoordinates(tester, ['e5', 'a8'], SquareType.white);
 
-      // edaxInit
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
       await tester.sendKeyEvent(InitShorcut.logicalKey);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
       await waitEdaxServerResponsed(tester);
       await tester.pump();
       expectStoneNum(tester, SquareType.black, 2);

--- a/test/home_test.dart
+++ b/test/home_test.dart
@@ -176,7 +176,9 @@ Future<void> main() async {
         expectStoneNum(tester, SquareType.white, 2);
         expectStoneCoordinates(tester, ['c5', 'e5'], SquareType.white);
 
-        await tester.sendKeyEvent(InitShorcut.logicalKey);
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+        await tester.sendKeyEvent(NewShorcut.logicalKey);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
         await waitEdaxServerResponsed(tester);
         await tester.pump();
         expectStoneNum(tester, SquareType.black, 2);
@@ -184,7 +186,9 @@ Future<void> main() async {
         expectStoneNum(tester, SquareType.white, 2);
         expectStoneCoordinates(tester, ['d4', 'e5'], SquareType.white);
 
-        await tester.sendKeyEvent(NewShorcut.logicalKey);
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
+        await tester.sendKeyEvent(InitShorcut.logicalKey);
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
         await waitEdaxServerResponsed(tester);
         await tester.pump();
         expectStoneNum(tester, SquareType.black, 2);

--- a/test/home_test.dart
+++ b/test/home_test.dart
@@ -6,8 +6,10 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:logger/logger.dart';
 import 'package:pedax/app.dart';
 import 'package:pedax/board/pedax_board.dart';
+import 'package:pedax/board/pedax_shortcuts/copy_moves_shortcut.dart';
 import 'package:pedax/board/pedax_shortcuts/init_shortcut.dart';
 import 'package:pedax/board/pedax_shortcuts/new_shortcut.dart';
+import 'package:pedax/board/pedax_shortcuts/paste_moves_shortcut.dart';
 import 'package:pedax/board/pedax_shortcuts/redo_all_shortcut.dart';
 import 'package:pedax/board/pedax_shortcuts/redo_shortcut.dart';
 import 'package:pedax/board/pedax_shortcuts/rotate180_shortcut.dart';
@@ -88,7 +90,7 @@ Future<void> main() async {
         expectStoneNum(tester, SquareType.white, 3);
         expectStoneCoordinates(tester, ['d4', 'e4', 'f4'], SquareType.white);
 
-        await tester.sendKeyEvent(RedoShorcut.logicalKeyR);
+        await tester.sendKeyEvent(RedoShorcut.logicalKey);
         await waitEdaxServerResponsed(tester);
         await tester.pump();
         expectStoneNum(tester, SquareType.black, 5);
@@ -307,7 +309,7 @@ Future<void> main() async {
 
       // paste
       await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
-      await tester.sendKeyEvent(LogicalKeyboardKey.keyV);
+      await tester.sendKeyEvent(PasteMovesShorcut.logicalKey);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
 
       await tester.pumpAndSettle();
@@ -317,7 +319,7 @@ Future<void> main() async {
 
       // copy
       await tester.sendKeyDownEvent(LogicalKeyboardKey.control);
-      await tester.sendKeyEvent(LogicalKeyboardKey.keyC);
+      await tester.sendKeyEvent(CopyMovesShorcut.logicalKey);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.control);
 
       await waitEdaxServerResponsed(tester);


### PR DESCRIPTION
when I want to enter shortcut key `U` , I sometimes enter `I` with a mistake.

In addition, breaking logic should be taken easily, it is desirable to require `ctrl/command.`