### PR TITLE
add missing `additional_cert_types: ["mac_installer_distribution"]`

### DIFF
--- a/macos/fastlane/Appfile
+++ b/macos/fastlane/Appfile
@@ -1,5 +1,5 @@
 app_identifier("com.done.sensuikan1973.pedax")
-apple_id(ENV["APPLE_ID"]) # Email Address
+apple_id(ENV["APPLE_ID"]) # Email Address. See: https://appleid.apple.com/
 
 itc_team_id(ENV["ITC_TEAM_ID"]) # App Store Connect Team ID
 team_id("Z2P4D5D6K2") # Developer Portal Team ID

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -33,6 +33,9 @@ platform :mac do
     # See: https://docs.fastlane.tools/actions/match
     match(
       platform: "macos",
+      # See: https://developer.apple.com/jp/support/certificates/
+      # See: https://help.apple.com/xcode/mac/current/#/dev80c6204ec
+      additional_cert_types: ["mac_installer_distribution"],
       api_key: api_key,
       app_identifier: 'com.done.sensuikan1973.pedax',
       type: "appstore",


### PR DESCRIPTION
So far, I use **local** Mac Installer Dicstribution implicitly, but I should use match feature.
I found the situation when my local cert expired.

```console
[17:48:42]: Successfully exported and compressed dSYM file
[17:48:43]: Successfully exported the .app file:
[17:48:43]: ./pedax.app
[17:48:43]: Generated plist file with the following values:
[17:48:43]: ▸ -----------------------------------------
[17:48:43]: ▸ {
[17:48:43]: ▸   "provisioningProfiles": {
[17:48:43]: ▸     "com.done.sensuikan1973.pedax": "match AppStore com.done.sensuikan1973.pedax macos"
[17:48:43]: ▸   },
[17:48:43]: ▸   "method": "app-store",
[17:48:43]: ▸   "signingStyle": "manual",
[17:48:43]: ▸   "installerSigningCertificate": "3rd Party Mac Developer Installer: Shimizu Naoki (Z2P4D5D6K2)",
[17:48:43]: ▸   "teamID": "Z2P4D5D6K2"
[17:48:43]: ▸ }
[17:48:43]: ▸ -----------------------------------------
[17:48:43]: $ /usr/bin/xcrun /foo/bar/FlutterProjects/pedax/macos/vendor/bundle/ruby/3.1.0/gems/fastlane-2.204.3/gym/lib/assets/wrap_xcodebuild/xcbuild-safe.sh -exportArchive -exportOptionsPlist '/var/folders/46/1s523x150xxd9twzzhtkzrch0000gn/T/gym_config20220313-47072-k5iflk.plist' -archivePath /foo/bar/Library/Developer/Xcode/Archives/2022-03-13/pedax\ 2022-03-13\ 17.46.47.xcarchive -exportPath '/var/folders/46/1s523x150xxd9twzzhtkzrch0000gn/T/gym_output20220313-47072-4eu3sc'
rbenv detected, removing env variables
rbenv: shell integration not enabled. Run `rbenv init' for instructions.
+ xcodebuild -exportArchive -exportOptionsPlist /var/folders/46/1s523x150xxd9twzzhtkzrch0000gn/T/gym_config20220313-47072-k5iflk.plist -archivePath '/foo/bar/Library/Developer/Xcode/Archives/2022-03-13/pedax 2022-03-13 17.46.47.xcarchive' -exportPath /var/folders/46/1s523x150xxd9twzzhtkzrch0000gn/T/gym_output20220313-47072-4eu3sc
2022-03-13 17:48:44.833 xcodebuild[47512:14898093] [MT] IDEDistribution: -[IDEDistributionLogging _createLoggingBundleAtPath:]: Created bundle at path "/var/folders/46/1s523x150xxd9twzzhtkzrch0000gn/T/Runner_2022-03-13_17-48-44.830.xcdistributionlogs".
2022-03-13 17:48:46.255 xcodebuild[47512:14898101]  DVTPortal: Service '<DVTPortalViewDeveloperService: 0x7fcdc0990290; action='viewDeveloper'>' encountered an unexpected result code from the portal ('1100')
2022-03-13 17:48:46.255 xcodebuild[47512:14898101]  DVTPortal: Error:
Error Domain=DVTPortalServiceErrorDomain Code=1100 "Your session has expired. Please log in." UserInfo={payload={
    creationTimestamp = "2022-03-13T08:48:50Z";
    httpCode = 200;
    protocolVersion = QH65B2;
    requestUrl = "https://developerservices2.apple.com/services/QH65B2/viewDeveloper.action";
    responseId = "a02219aa-f1f0-4084-b088-b61d0a3e1703";
    resultCode = 1100;
    resultString = "Your session has expired. Please log in.";
    userLocale = "en_US";
    userString = "Your session has expired. Please log in.";
}, NSLocalizedDescription=Your session has expired. Please log in.}
2022-03-13 17:48:46.261 xcodebuild[47512:14898095]  IDEDistribution: Failed to log in with account "foo@gmail.com" while checking for an App Store Connect account
error: exportArchive: Signing certificate is invalid.

Error Domain=IDECodesignResolverErrorDomain Code=3 "Signing certificate is invalid." UserInfo={IDEProvisioningError_UserInfoKey_IDEProvisioningErrorAction=5, NSLocalizedRecoverySuggestion=Signing certificate "3rd Party Mac Developer Installer: Shimizu Naoki (Z2P4D5D6K2)", serial number "2F6C56921E4760265EE0BF67A6762973", is not valid for code signing. It may have been revoked or expired., IDEProvisioningError_UserInfoKey_IDEProvisioningErrorTeam=<IDEProvisioningBasicTeam: 0x7fcdb44bef30; teamID='Z2P4D5D6K2', teamName='Shimizu Naoki'>, IDEProvisioningError_UserInfoKey_IDEProvisioningErrorPlatform=com.apple.platform.macosx, NSLocalizedDescription=Signing certificate is invalid.}

** EXPORT FAILED **
[17:48:46]: Exit status: 70

+---------------+-------------------------+
|            Build environment            |
+---------------+-------------------------+
| xcode_path    | /Applications/Xcode.app |
| gym_version   | 2.204.3                 |
| export_method | app-store               |
| sdk           | MacOSX12.1.sdk          |
+---------------+-------------------------+

[17:48:46]: ▸ RegisterWithLaunchServices /foo/bar/Library/Developer/Xcode/DerivedData/Runner-dqlhvwmzymbupogziibooalmsfpk/Build/Intermediates.noindex/ArchiveIntermediates/Runner/InstallationBuildProductsLocation/Applications/pedax.app (in target 'Runner' from project 'Runner')
[17:48:46]: ▸     cd /foo/bar/FlutterProjects/pedax/macos
[17:48:46]: ▸     /System/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister -f -R -trusted /foo/bar/Library/Developer/Xcode/DerivedData/Runner-dqlhvwmzymbupogziibooalmsfpk/Build/Intermediates.noindex/ArchiveIntermediates/Runner/InstallationBuildProductsLocation/Applications/pedax.app
[17:48:46]: ▸ ** ARCHIVE SUCCEEDED ** [108.616 sec]
[17:48:46]:
[17:48:46]: ⬆️  Check out the few lines of raw `xcodebuild` output above for potential hints on how to solve this error
[17:48:46]: 📋  For the complete and more detailed error log, check the full log at:
[17:48:46]: 📋  /foo/bar/Library/Logs/gym/pedax-Runner.log
[17:48:46]:
[17:48:46]: Looks like fastlane ran into a build/archive error with your project
[17:48:46]: It's hard to tell what's causing the error, so we wrote some guides on how
[17:48:46]: to troubleshoot build and signing issues: https://docs.fastlane.tools/codesigning/getting-started/
[17:48:46]: Before submitting an issue on GitHub, please follow the guide above and make
[17:48:46]: sure your project is set up correctly.
[17:48:46]: fastlane uses `xcodebuild` commands to generate your binary, you can see the
[17:48:46]: the full commands printed out in yellow in the above log.
[17:48:46]: Make sure to inspect the output above, as usually you'll find more error information there
[17:48:46]:
+------------------------------------+---------------------------------------------------+
|                                      Lane Context                                      |
+------------------------------------+---------------------------------------------------+
| DEFAULT_PLATFORM                   | mac                                               |
| PLATFORM_NAME                      | mac                                               |
| LANE_NAME                          | mac deploy_app_store                              |
| SIGH_PROFILE_TYPE                  | app-store                                         |
| MATCH_PROVISIONING_PROFILE_MAPPING | {"com.done.sensuikan1973.pedax"=>"match AppStore  |
|                                    | com.done.sensuikan1973.pedax macos"}              |
+------------------------------------+---------------------------------------------------+
[17:48:46]: Error packaging up the application

+------+---------------------------+-------------+
|                fastlane summary                |
+------+---------------------------+-------------+
| Step | Action                    | Time (in s) |
+------+---------------------------+-------------+
| 1    | default_platform          | 0           |
| 2    | app_store_connect_api_key | 0           |
| 3    | is_ci                     | 0           |
| 4    | match                     | 4           |
| 💥   | build_mac_app             | 130         |
+------+---------------------------+-------------+

[17:48:46]: fastlane finished with errors

[!] Error packaging up the application
zsh: exit 1     ASC_KEY_ID=N3YMRHMBJG ASC_ISSUER_ID=69a6de95-5d86-47e3-e053-5b8c7c11a4d1 = =
```