### PR TITLE
bundle coverage reports on multiple platform

### DIFF
--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -70,13 +70,13 @@ jobs:
         include:
           - os: windows-latest
             setup_for_flutter_desktop_script: .github/scripts/windows/install_additional_requirements_for_flutter.sh
-            integration_test_command: flutter test integration_test
+            integration_test_command: flutter test integration_test --coverage --coverage-path=./coverage/lcov.info
           - os: macos-latest
             setup_for_flutter_desktop_script: .github/scripts/macos/install_additional_requirements_for_flutter.sh
-            integration_test_command: flutter test integration_test
+            integration_test_command: flutter test integration_test --coverage --coverage-path=./coverage/lcov.info
           - os: ubuntu-latest
             setup_for_flutter_desktop_script: .github/scripts/linux/install_additional_requirements_for_flutter.sh
-            integration_test_command: 'timeout 180 xvfb-run -a flutter test integration_test || ( [[ $? -eq 124 ]] && echo "WARNING: timeout" )'
+            integration_test_command: 'timeout 180 xvfb-run -a flutter test integration_test --coverage --coverage-path=./coverage/lcov.info || ( [[ $? -eq 124 ]] && echo "WARNING: timeout" )'
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2.4.0
@@ -90,23 +90,27 @@ jobs:
         run: flutter doctor -v
       - name: install dependencies
         run: flutter pub get
+
       - name: run widget test with retry
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 3
           command: flutter test --concurrency=1 --coverage --coverage-path=./coverage/lcov.info
-
       - uses: codecov/codecov-action@v3
         with: # ref: https://github.com/codecov/codecov-action/blob/v3.1.0/.github/workflows/main.yml
           files: ./coverage/lcov.info
           flags: widget_test,${{ matrix.os }}
           fail_ci_if_error: true
 
-      # TODO: uncommentout
-      # - name: run integration test with retry
-      #   uses: nick-invision/retry@v2
-      #   with:
-      #     timeout_minutes: 5
-      #     max_attempts: 3
-      #     command: ${{ matrix.integration_test_command }}
+      - name: run integration test with retry
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: ${{ matrix.integration_test_command }}
+      - uses: codecov/codecov-action@v3
+        with: # ref: https://github.com/codecov/codecov-action/blob/v3.1.0/.github/workflows/main.yml
+          files: ./coverage/lcov.info
+          flags: integration_test,${{ matrix.os }}
+          fail_ci_if_error: true

--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -96,12 +96,13 @@ jobs:
           timeout_minutes: 5
           max_attempts: 3
           command: flutter test --concurrency=1 --verbose --coverage --coverage-path=./coverage/lcov.${{ matrix.os }}.info
-      - name: run integration test with retry
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 5
-          max_attempts: 3
-          command: ${{ matrix.integration_test_command }}
+      # TODO: uncommentout
+      # - name: run integration test with retry
+      #   uses: nick-invision/retry@v2
+      #   with:
+      #     timeout_minutes: 5
+      #     max_attempts: 3
+      #     command: ${{ matrix.integration_test_command }}
 
       - uses: actions/upload-artifact@v3
         with:
@@ -117,5 +118,5 @@ jobs:
       - run: ls -la artifact
       - uses: codecov/codecov-action@v3
         with:
-          files: ./artifact/lcov.windows-latest.info,./artifact/lcov.macos-latest.info,./artifact/lcov.ubuntu-latest.info
+          files: ./artifact/lcov.*.info
           fail_ci_if_error: true

--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -95,13 +95,27 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 3
-          command: flutter test --concurrency=1 --verbose --coverage --coverage-path=./coverage/lcov.info
+          command: flutter test --concurrency=1 --verbose --coverage --coverage-path=./coverage/lcov.${{ matrix.os }}.info
       - name: run integration test with retry
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 5
           max_attempts: 3
           command: ${{ matrix.integration_test_command }}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./coverage/lcov.${{ matrix.os }}.info
+
+  # See: https://about.codecov.io/blog/uploading-code-coverage-in-a-separate-job-on-github-actions/
+  upload_coverage_report_to_codecov:
+    needs: [flutter_tests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          path: ./coverage
       - uses: codecov/codecov-action@v3
         with:
-          file: ./coverage/lcov.info
+          files: ./coverage/lcov.windows-latest.info,./coverage/lcov.macos-latest.info,./coverage/lcov.ubuntu-latest.info

--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -114,8 +114,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/download-artifact@v3
-      - run: ls -la
+      - run: ls -la artifact
       - uses: codecov/codecov-action@v3
         with:
-          files: ./coverage/lcov.windows-latest.info,./coverage/lcov.macos-latest.info,./coverage/lcov.ubuntu-latest.info
+          files: ./artifact/lcov.windows-latest.info,./artifact/lcov.macos-latest.info,./artifact/lcov.ubuntu-latest.info
           fail_ci_if_error: true

--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -95,7 +95,14 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 3
-          command: flutter test --concurrency=1 --verbose --coverage --coverage-path=./coverage/lcov.${{ matrix.os }}.info
+          command: flutter test --concurrency=1 --verbose --coverage --coverage-path=./coverage/lcov.info
+
+      - uses: codecov/codecov-action@v3
+        with: # ref: https://github.com/codecov/codecov-action/blob/v3.1.0/.github/workflows/main.yml
+          files: ./coverage/lcov.info
+          flags: widget_test,${{ matrix.os }}
+          fail_ci_if_error: true
+
       # TODO: uncommentout
       # - name: run integration test with retry
       #   uses: nick-invision/retry@v2
@@ -103,20 +110,3 @@ jobs:
       #     timeout_minutes: 5
       #     max_attempts: 3
       #     command: ${{ matrix.integration_test_command }}
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./coverage/lcov.${{ matrix.os }}.info
-
-  # See: https://about.codecov.io/blog/uploading-code-coverage-in-a-separate-job-on-github-actions/
-  upload_coverage_report_to_codecov:
-    needs: [flutter_tests]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/download-artifact@v3
-      - run: ls -la artifact
-      - uses: codecov/codecov-action@v3
-        with:
-          files: ./artifact/lcov.*.info
-          fail_ci_if_error: true

--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -70,13 +70,13 @@ jobs:
         include:
           - os: windows-latest
             setup_for_flutter_desktop_script: .github/scripts/windows/install_additional_requirements_for_flutter.sh
-            integration_test_command: flutter test integration_test --verbose
+            integration_test_command: flutter test integration_test
           - os: macos-latest
             setup_for_flutter_desktop_script: .github/scripts/macos/install_additional_requirements_for_flutter.sh
-            integration_test_command: flutter test integration_test --verbose
+            integration_test_command: flutter test integration_test
           - os: ubuntu-latest
             setup_for_flutter_desktop_script: .github/scripts/linux/install_additional_requirements_for_flutter.sh
-            integration_test_command: 'timeout 180 xvfb-run -a flutter test integration_test --verbose || ( [[ $? -eq 124 ]] && echo "WARNING: timeout" )'
+            integration_test_command: 'timeout 180 xvfb-run -a flutter test integration_test || ( [[ $? -eq 124 ]] && echo "WARNING: timeout" )'
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2.4.0
@@ -95,7 +95,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 3
-          command: flutter test --concurrency=1 --verbose --coverage --coverage-path=./coverage/lcov.info
+          command: flutter test --concurrency=1 --coverage --coverage-path=./coverage/lcov.info
 
       - uses: codecov/codecov-action@v3
         with: # ref: https://github.com/codecov/codecov-action/blob/v3.1.0/.github/workflows/main.yml

--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -114,8 +114,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/download-artifact@v3
-        with:
-          path: ./coverage
+      - run: ls -la
       - uses: codecov/codecov-action@v3
         with:
           files: ./coverage/lcov.windows-latest.info,./coverage/lcov.macos-latest.info,./coverage/lcov.ubuntu-latest.info
+          fail_ci_if_error: true


### PR DESCRIPTION
I want to remove the randomness of coverage report.
It's because coverage report is created by one platform test result which finished lastly.
See: https://github.com/codecov/codecov-action/blob/v3.1.0/.github/workflows/main.yml