### PR TITLE
fix bug of flutter_deps workflow

### DIFF
--- a/.github/workflows/flutter_deps.yaml
+++ b/.github/workflows/flutter_deps.yaml
@@ -22,6 +22,7 @@ jobs:
         shell: zsh {0} # See: https://github.com/actions/virtual-environments/issues/264#issuecomment-574032011
         run: ./scripts/setup_flutter.sh
 
+      - run: flutter pub get
       - name: install native deps on macs
         if: runner.os == 'macOS'
         working-directory: macos


### PR DESCRIPTION
resolve https://github.com/sensuikan1973/pedax/runs/6397649819?check_suite_focus=true

```
Run which pod && pod --version && pod install
/usr/local/lib/ruby/gems/2.[7](https://github.com/sensuikan1973/pedax/runs/6397649819?check_suite_focus=true#step:6:7).0/bin/pod
1.11.3

[!] Invalid `Podfile` file: /Users/runner/work/pedax/pedax/macos/Flutter/ephemeral/Flutter-Generated.xcconfig must exist. If you're running pod install manually, make sure "flutter pub get" is executed first.

 #  from /Users/runner/work/pedax/pedax/macos/Podfile:15
 #  -------------------------------------------
 #    unless File.exist?(generated_xcode_build_settings_path)
 >      raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
 #    end
 #  -------------------------------------------
```