### PR TITLE
remove wrong update command

### DIFF
--- a/.github/workflows/flutter_deps.yaml
+++ b/.github/workflows/flutter_deps.yaml
@@ -32,11 +32,6 @@ jobs:
 
       - run: dart fix --apply
 
-      - name: update native deps on macs
-        if: runner.os == 'macOS'
-        working-directory: macos
-        run: which pod && pod --version && pod update
-
       - name: upgrade external binary
         shell: zsh {0}
         run: ./scripts/fetch_libedax_assets.sh


### PR DESCRIPTION
`pod install` manually is not recommended. We should run `flutter pub get` only.

ref: https://github.com/flutter/flutter/issues/73845