### PR TITLE
Revert "set `ITSAppUsesNonExemptEncryption` true, e.g. `HTTPS`"

### DIFF
--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -29,7 +29,7 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<!-- https://developer.apple.com/documentation/security/complying_with_encryption_export_regulations -->
 	<key>ITSAppUsesNonExemptEncryption</key>
-	<true/>
+	<false/>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.board-games</string>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
Reverts sensuikan1973/pedax#1170

<img width="665" alt="image" src="https://user-images.githubusercontent.com/23427957/210873084-3e5409fa-ffd3-4bca-a123-c349cfaf1355.png">

<img width="637" alt="image" src="https://user-images.githubusercontent.com/23427957/210873115-b73c2e5e-25b4-42d1-8202-d24d7e81b429.png">

So, `ITSAppUsesNonExemptEncryption` should be **false**
