### PR TITLE
fastlane change `export_compliance_is_exempt` from `false` to `true`

### DIFF
--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -80,7 +80,7 @@ platform :mac do
         export_compliance_encryption_updated: false,
         export_compliance_app_type: nil,
         export_compliance_uses_encryption: true, # e.g. HTTPS
-        export_compliance_is_exempt: false,
+        export_compliance_is_exempt: true, # See: https://github.com/sensuikan1973/pedax/pull/1172
         export_compliance_contains_third_party_cryptography: false,
         export_compliance_contains_proprietary_cryptography: false,
         export_compliance_available_on_french_store: false, # avoid to upload legal documentation, and french is not important region for pedax.


### PR DESCRIPTION
See: https://github.com/sensuikan1973/pedax/pull/1172