### PR TITLE
codecov enable `wait_for_ci`

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,6 +3,7 @@
 
 codecov:
   notify:
+    wait_for_ci: yes
     require_ci_to_pass: yes
 
 coverage:


### PR DESCRIPTION
resolve https://github.com/sensuikan1973/pedax/issues/1165

See: https://docs.codecov.com/docs/codecovyml-reference#codecovnotifywait_for_ci