### PR TITLE
support intel silicon mac Properly

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -16,23 +16,34 @@ jobs:
     if: ${{ github.head_ref == 'prepare_for_release' && github.event.pull_request.merged == true }}
     env:
       PUBLISH_DIR: publish
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner_machine }}
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-intel-silicon, macos-latest]
         include:
           - os: ubuntu-latest
+            runner_machine: ubuntu-latest
             subcommand: linux
             setup_for_flutter_desktop_script: .github/scripts/linux/install_additional_requirements_for_flutter.sh
             prepare_to_pack_script: .github/scripts/linux/prepare_to_pack.sh
             distribution_path: build/linux/x64/release/bundle # https://docs.flutter.dev/desktop#linux
           - os: windows-latest
+            runner_machine: windows-latest
             subcommand: windows
             setup_for_flutter_desktop_script: .github/scripts/windows/install_additional_requirements_for_flutter.sh
             prepare_to_pack_script: .github/scripts/windows/prepare_to_pack.sh
             distribution_path: build/windows/x64/runner/Release # https://docs.flutter.dev/release/breaking-changes/windows-build-architecture
+          - os: macos-intel-silicon
+            # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+            runner_machine: macos-13
+            subcommand: macos
+            setup_for_flutter_desktop_script: .github/scripts/macos/install_additional_requirements_for_flutter.sh
+            prepare_to_pack_script: .github/scripts/macos/prepare_to_pack.sh
+            distribution_path: build/macos/Build/Products/release
           - os: macos-latest
+            # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+            runner_machine: macos-latest
             subcommand: macos
             setup_for_flutter_desktop_script: .github/scripts/macos/install_additional_requirements_for_flutter.sh
             prepare_to_pack_script: .github/scripts/macos/prepare_to_pack.sh
@@ -71,13 +82,13 @@ jobs:
         run: |-
           mkdir -p ${{ env.PUBLISH_DIR }}
           cd ${{ matrix.distribution_path }}
-          powershell Compress-Archive -Path ./* -DestinationPath $Env:GITHUB_WORKSPACE/${{ env.PUBLISH_DIR }}/pedax-${{ runner.os }}.zip
+          powershell Compress-Archive -Path ./* -DestinationPath $Env:GITHUB_WORKSPACE/${{ env.PUBLISH_DIR }}/pedax-${{ matrix.os }}.zip
       - name: compress files (macOS, Linux)
         if: runner.os == 'macOS' || runner.os == 'Linux'
         run: |-
           mkdir -p ${{ env.PUBLISH_DIR }}
           cd ${{ matrix.distribution_path }}
-          zip -r $GITHUB_WORKSPACE/${{ env.PUBLISH_DIR }}/pedax-${{ runner.os }}.zip .
+          zip -r $GITHUB_WORKSPACE/${{ env.PUBLISH_DIR }}/pedax-${{ matrix.os }}.zip .
 
       - uses: softprops/action-gh-release@v2
         env:
@@ -85,7 +96,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         with:
           tag_name: ${{ env.CURRENT_VERSION }}
-          files: ${{ env.PUBLISH_DIR }}/pedax-${{ runner.os }}.zip
+          files: ${{ env.PUBLISH_DIR }}/pedax-${{ matrix.os }}.zip
           generate_release_notes: true
           # body: This is created by $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID.
           # append_body: true

--- a/.github/workflows/flutter_build.yaml
+++ b/.github/workflows/flutter_build.yaml
@@ -90,5 +90,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: pedax-${{ runner.os }}
+          name: pedax-${{ matrix.os }}
           path: ${{ matrix.distribution_path }}

--- a/.github/workflows/flutter_build.yaml
+++ b/.github/workflows/flutter_build.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false # I want results from all OSes even if one fails.
       matrix:
-        os: [ubuntu, windows, macos]
+        os: [ubuntu, windows, macos-intel-silicon, macos-latest]
         include: # See: https://docs.github.com/ja/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#using-environment-variables-in-a-matrix
           - os: ubuntu
             runner_machine: ubuntu-latest
@@ -35,7 +35,13 @@ jobs:
             setup_for_flutter_desktop_script: .github/scripts/windows/install_additional_requirements_for_flutter.sh
             prepare_to_pack_script: .github/scripts/windows/prepare_to_pack.sh
             distribution_path: build/windows/x64/runner/Release # https://docs.flutter.dev/release/breaking-changes/windows-build-architecture
-          - os: macos
+          - os: macos-intel-silicon
+            runner_machine: macos-13
+            subcommand: macos
+            setup_for_flutter_desktop_script: .github/scripts/macos/install_additional_requirements_for_flutter.sh
+            prepare_to_pack_script: .github/scripts/macos/prepare_to_pack.sh
+            distribution_path: build/macos/Build/Products/release
+          - os: macos-latest
             runner_machine: macos-latest
             subcommand: macos
             setup_for_flutter_desktop_script: .github/scripts/macos/install_additional_requirements_for_flutter.sh

--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
-        os: [windows, macos-intel-silicon, macos-apple-silicon, ubuntu]
+        os: [windows, macos-intel-silicon, macos-latest, ubuntu]
         include:
           - os: windows
             runner_machine: windows-latest
@@ -61,7 +61,7 @@ jobs:
             # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
             runner_machine: macos-13
             setup_for_flutter_desktop_script: .github/scripts/macos/install_additional_requirements_for_flutter.sh
-          - os: macos-apple-silicon
+          - os: macos-latest
             # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
             runner_machine: macos-14
             setup_for_flutter_desktop_script: .github/scripts/macos/install_additional_requirements_for_flutter.sh

--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -102,7 +102,7 @@ jobs:
     strategy:
       fail-fast: false # for https://github.com/sensuikan1973/pedax/issues/1221
       matrix: # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs
-        os: [windows, macos-intel-silicon, macos-apple-silicon, ubuntu]
+        os: [windows, macos-intel-silicon, macos-latest, ubuntu]
         include:
           - os: windows
             runner_machine: windows-latest
@@ -110,14 +110,13 @@ jobs:
             # workaround for https://github.com/sensuikan1973/pedax/pull/1746#issuecomment-1975666851
             integration_test_command: flutter test integration_test --device-id windows --verbose --coverage --coverage-path=./coverage/lcov.integration_test.info
           - os: macos-intel-silicon
-            # Why isn't this macos-latest ? -> workaround for https://github.com/sensuikan1973/pedax/pull/1443
             # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
             runner_machine: macos-13
             setup_for_flutter_desktop_script: .github/scripts/macos/install_additional_requirements_for_flutter.sh
             integration_test_command: flutter test integration_test --device-id macos --verbose --coverage --coverage-path=./coverage/lcov.integration_test.info
-          - os: macos-apple-silicon
+          - os: macos-latest
             # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
-            runner_machine: macos-14
+            runner_machine: macos-latest
             setup_for_flutter_desktop_script: .github/scripts/macos/install_additional_requirements_for_flutter.sh
             integration_test_command: flutter test integration_test --device-id macos --verbose --coverage --coverage-path=./coverage/lcov.integration_test.info
           - os: ubuntu


### PR DESCRIPTION
Explicitly support both apple silicon macs and intel silicon macs, since macos-latest in github actions recently became apple silicon mac.

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories