### PR TITLE
follow window_manager usage updated on windows

### DIFF
--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -29,7 +29,7 @@ bool FlutterWindow::OnCreate() {
 
   flutter_controller_->engine()->SetNextFrameCallback([&]() {
     // See: https://github.com/leanflutter/window_manager?tab=readme-ov-file#hidden-at-launch
-     ""
+     "";
   });
 
   // Flutter can complete the first frame before the "show window" callback is


### PR DESCRIPTION
See: https://github.com/leanflutter/window_manager?tab=readme-ov-file#hidden-at-launch

> Since flutter 3.7 new windows project Change the file windows/runner/flutter_window.cpp as follows:
```diff
bool FlutterWindow::OnCreate() {
  ...
  flutter_controller_->engine()->SetNextFrameCallback([&]() {
-   this->Show();
+   "" //delete this->Show()
  });
```